### PR TITLE
Add image encoding base

### DIFF
--- a/src/Eidolon/Cargo.toml
+++ b/src/Eidolon/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "Eidolon"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]] # Bin to run the HelloWorld gRPC server
+name = "Eidolon"
+path = "src/main.rs"
+
+
+[dependencies]
+tonic = "*"
+prost = "0.14"
+tonic-prost = "*"
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+tonic-health = "0.14.2"
+
+anyhow = "1.0"
+candle-core = { version = "0.9.1", features = ["metal"] }
+candle-nn = { version = "0.9.1", features = ["metal"] }
+candle-transformers = { version = "0.9.1", features = ["metal"] }
+hf-hub = "0.4.3"
+tokenizers = { version = "0.22.1", features = ["onig"] }
+serde = { version = "1.0.226", features = ["derive"] }
+serde_json = "1.0.145"
+csv = "1.3.1"
+futures = "0.3.31"
+tokio-stream = "0.1.17"
+governor = "0.10.1"
+image = "0.25.8"
+
+[build-dependencies]
+tonic-build = "0.14.2"
+tonic-prost-build = "0.14.2"

--- a/src/Eidolon/build.rs
+++ b/src/Eidolon/build.rs
@@ -1,0 +1,15 @@
+/*fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Compile the helloworld service
+    tonic_prost_build::compile_protos("proto/helloworld.proto")?;
+
+    // Compile the health service
+    tonic_prost_build::compile_protos("proto/health.proto")?;
+
+    tonic_prost_build::compile_protos("proto/clip.proto")?;
+
+    Ok(())
+}*/
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_prost_build::compile_protos("proto/clip.proto")?;
+    Ok(())
+}

--- a/src/Eidolon/proto/clip.proto
+++ b/src/Eidolon/proto/clip.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+package clip;
+// The CLIP service definition for multimodal embeddings.
+service ClipEmbedder {
+  // Generates an embedding for a single text query.
+  rpc EmbedText(EmbedTextRequest) returns (EmbedResponse);
+  // Generates an embedding for a single image query.
+  rpc EmbedImage(EmbedImageRequest) returns (EmbedResponse);
+  // Indexes a stream of images for bulk processing.
+  rpc IndexImages(stream IndexImageRequest) returns (stream IndexResponse);
+}
+
+// Represents a single embedding vector.
+message Embedding {
+  repeated float values = 1;
+}
+
+// == Unary RPC Messages ==
+message EmbedTextRequest {
+  string text = 1;
+}
+
+message EmbedImageRequest {
+  // Image content, encoded as bytes (e.g., JPEG, PNG).
+  bytes image = 1;
+}
+
+message EmbedResponse {
+  Embedding embedding = 1;
+}
+
+// == Streaming RPC Messages ==
+message IndexImageRequest {
+  string document_id = 1;
+  bytes image = 2;
+}
+
+message IndexResponse {
+  string document_id = 1;
+  Embedding embedding = 2;
+  bool success = 3;
+}

--- a/src/Eidolon/proto/health.proto
+++ b/src/Eidolon/proto/health.proto
@@ -1,0 +1,63 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The canonical version of this proto can be found at
+// https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto
+
+syntax = "proto3";
+
+package grpc.health.v1;
+
+option csharp_namespace = "Grpc.Health.V1";
+option go_package = "google.golang.org/grpc/health/grpc_health_v1";
+option java_multiple_files = true;
+option java_outer_classname = "HealthProto";
+option java_package = "io.grpc.health.v1";
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  // If the requested service is unknown, the call will fail with status
+  // NOT_FOUND.
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+  // Performs a watch for the serving status of the requested service.
+  // The server will immediately send back a message indicating the current
+  // serving status.  It will then subsequently send a new message whenever
+  // the service's serving status changes.
+  //
+  // If the requested service is unknown when the call is received, the
+  // server will send a message setting the serving status to
+  // SERVICE_UNKNOWN but will *not* terminate the call.  If at some
+  // future point, the serving status of the service becomes known, the
+  // server will send a new message with the service's serving status.
+  //
+  // If the call terminates with status UNIMPLEMENTED, then clients
+  // should assume this method is not supported and should not retry the
+  // call.  If the call terminates with any other status (including OK),
+  // clients should retry the call with appropriate exponential backoff.
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/src/Eidolon/proto/helloworld.proto
+++ b/src/Eidolon/proto/helloworld.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package helloworld;
+
+service Greeter {
+  rpc SayHello(HelloRequest) returns (HelloReply);
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}

--- a/src/Eidolon/src/clipembedder/mod.rs
+++ b/src/Eidolon/src/clipembedder/mod.rs
@@ -1,0 +1,4 @@
+pub mod model;
+pub mod service;
+pub mod proto;
+

--- a/src/Eidolon/src/clipembedder/model.rs
+++ b/src/Eidolon/src/clipembedder/model.rs
@@ -1,0 +1,123 @@
+use anyhow::{Error as E, Result};
+use candle_core::{DType, Device, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::clip;
+use hf_hub::api::sync::Api;
+use hf_hub::{Repo, RepoType};
+use tokenizers::Tokenizer;
+
+pub struct ClipEmbeddingModel {
+    model: clip::ClipModel,
+    tokenizer: Tokenizer,
+    pub device: Device,
+    image_size: usize,
+}
+
+impl ClipEmbeddingModel {
+    /// Creates a new model from the HuggingFace hub.
+    pub fn new(model_id: &str) -> Result<Self> {
+        let device = if candle_core::utils::metal_is_available() {
+            Device::new_metal(0)?
+        } else {
+            Device::Cpu
+        };
+
+        // Use the exact repository details from the working example
+        let api = Api::new()?;
+        let repo = api.repo(Repo::with_revision(
+            model_id.to_string(),
+            RepoType::Model,
+            "refs/pr/15".to_string(), // Specific revision from the example
+        ));
+
+        let model_filename = repo.get("model.safetensors")?;
+        let tokenizer_filename = repo.get("tokenizer.json")?;
+
+        let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
+
+        // Use the hardcoded config from the example, which is simpler and more reliable
+        let config = clip::ClipConfig::vit_base_patch32();
+        let image_size = config.image_size;
+
+        let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_filename], DType::F32, &device)? };
+        // Use the simpler constructor from the example
+        let model = clip::ClipModel::new(vb, &config)?;
+
+        Ok(Self {
+            model,
+            tokenizer,
+            device,
+            image_size,
+        })
+    }
+
+    /// Generates embeddings for a batch of text.
+    pub fn embed_texts(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        let pad_id = *self
+            .tokenizer
+            .get_vocab(true)
+            .get("<|endoftext|>")
+            .ok_or(E::msg("No pad token"))?;
+
+        let mut tokens = vec![];
+        for text in texts {
+            let encoding = self.tokenizer.encode(text.clone(), true).map_err(E::msg)?;
+            tokens.push(encoding.get_ids().to_vec());
+        }
+
+        let max_len = tokens.iter().map(|v| v.len()).max().unwrap_or(0);
+        for token_vec in tokens.iter_mut() {
+            let len_diff = max_len - token_vec.len();
+            if len_diff > 0 {
+                token_vec.extend(vec![pad_id; len_diff]);
+            }
+        }
+
+        let token_ids = Tensor::new(tokens, &self.device)?;
+        let embeddings = self.model.get_text_features(&token_ids)?;
+
+        // Normalize embeddings, which is crucial for similarity search
+        let embeddings = normalize_l2(&embeddings)?;
+        Ok(embeddings.to_vec2()?)
+    }
+
+    /// Generates embeddings for a batch of images provided as raw bytes.
+    pub fn embed_images(&self, image_bytes_batch: &[Vec<u8>]) -> Result<Vec<Vec<f32>>> {
+        let mut image_tensors = vec![];
+        for image_bytes in image_bytes_batch {
+            let tensor = self.preprocess_image(image_bytes)?;
+            image_tensors.push(tensor);
+        }
+        let image_tensors = Tensor::stack(&image_tensors, 0)?.to_device(&self.device)?;
+
+        let embeddings = self.model.get_image_features(&image_tensors)?;
+        let embeddings = normalize_l2(&embeddings)?;
+        Ok(embeddings.to_vec2()?)
+    }
+
+    /// Preprocesses a single image from bytes into a tensor.
+    /// This logic is taken directly from the working example you provided.
+    fn preprocess_image(&self, image_bytes: &[u8]) -> Result<Tensor> {
+        let img = image::load_from_memory(image_bytes)?;
+        let (height, width) = (self.image_size, self.image_size);
+
+        let img = img.resize_to_fill(
+            width as u32,
+            height as u32,
+            image::imageops::FilterType::Triangle,
+        );
+        let img = img.to_rgb8();
+        let img_data = img.into_raw();
+
+        let tensor = Tensor::from_vec(img_data, (height, width, 3), &Device::Cpu)?
+            .permute((2, 0, 1))?
+            .to_dtype(DType::F32)?
+            .affine(2. / 255., -1.)?; // Normalization
+        Ok(tensor)
+    }
+}
+
+/// Helper function to normalize the embeddings.
+fn normalize_l2(v: &Tensor) -> Result<Tensor> {
+    Ok(v.broadcast_div(&v.sqr()?.sum_keepdim(1)?.sqrt()?)?)
+}

--- a/src/Eidolon/src/clipembedder/proto.rs
+++ b/src/Eidolon/src/clipembedder/proto.rs
@@ -1,0 +1,4 @@
+tonic::include_proto!("clip");
+
+pub use clip_embedder_server::*;
+

--- a/src/Eidolon/src/clipembedder/service.rs
+++ b/src/Eidolon/src/clipembedder/service.rs
@@ -1,0 +1,168 @@
+use crate::clipembedder::model::ClipEmbeddingModel;
+use crate::clipembedder::proto::{
+    ClipEmbedder, EmbedImageRequest, EmbedResponse, EmbedTextRequest, Embedding, IndexImageRequest,
+    IndexResponse,
+};
+use futures::{Stream, StreamExt};
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status, Streaming};
+
+pub struct ClipEmbedderService {
+    pub model: Arc<Mutex<ClipEmbeddingModel>>,
+}
+
+struct ImageBatch {
+    document_ids: Vec<String>,
+    images: Vec<Vec<u8>>,
+}
+
+#[tonic::async_trait]
+impl ClipEmbedder for ClipEmbedderService {
+    async fn embed_text(
+        &self,
+        request: Request<EmbedTextRequest>,
+    ) -> Result<Response<EmbedResponse>, Status> {
+        let text = request.into_inner().text;
+        if text.is_empty() {
+            return Err(Status::invalid_argument("Text cannot be empty"));
+        }
+
+        let model = self.model.clone();
+        let embedding = tokio::task::spawn_blocking(move || model.lock().unwrap().embed_texts(&[text]))
+            .await
+            .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+            .map_err(|e| Status::internal(format!("Embedding generation failed: {}", e)))?
+            .pop()
+            .ok_or_else(|| Status::internal("Model returned no embedding"))?;
+
+        Ok(Response::new(EmbedResponse {
+            embedding: Some(Embedding { values: embedding }),
+        }))
+    }
+
+    async fn embed_image(
+        &self,
+        request: Request<EmbedImageRequest>,
+    ) -> Result<Response<EmbedResponse>, Status> {
+        let image_bytes = request.into_inner().image;
+        if image_bytes.is_empty() {
+            return Err(Status::invalid_argument("Image bytes cannot be empty"));
+        }
+
+        let model = self.model.clone();
+        let embedding = tokio::task::spawn_blocking(move || {
+            model.lock().unwrap().embed_images(&[image_bytes.clone()])
+        })
+            .await
+            .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+            .map_err(|e| Status::internal(format!("Embedding generation failed: {}", e)))?
+            .pop()
+            .ok_or_else(|| Status::internal("Model returned no embedding"))?;
+
+        Ok(Response::new(EmbedResponse {
+            embedding: Some(Embedding { values: embedding }),
+        }))
+    }
+
+    type IndexImagesStream = Pin<Box<dyn Stream<Item = Result<IndexResponse, Status>> + Send>>;
+
+    async fn index_images(
+        &self,
+        request: Request<Streaming<IndexImageRequest>>,
+    ) -> Result<Response<Self::IndexImagesStream>, Status> {
+        let mut request_stream = request.into_inner();
+        let model = self.model.clone();
+        let (batch_tx, mut batch_rx) = mpsc::channel::<ImageBatch>(4);
+        let (response_tx, response_rx) = mpsc::channel(32);
+
+        // Worker task to process image batches
+        tokio::spawn(async move {
+            while let Some(batch) = batch_rx.recv().await {
+                let model = model.clone();
+                let response_tx = response_tx.clone();
+                tokio::task::spawn_blocking(move || {
+                    let embeddings_result = model.lock().unwrap().embed_images(&batch.images);
+                    match embeddings_result {
+                        Ok(embeddings) => {
+                            for (i, doc_id) in batch.document_ids.iter().enumerate() {
+                                let response = IndexResponse {
+                                    document_id: doc_id.clone(),
+                                    embedding: embeddings
+                                        .get(i)
+                                        .map(|v| Embedding { values: v.clone() }),
+                                    success: true,
+                                };
+                                if response_tx.blocking_send(Ok(response)).is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("Batch embedding failed: {:?}", e);
+                            for doc_id in batch.document_ids {
+                                let response = IndexResponse {
+                                    document_id: doc_id,
+                                    embedding: None,
+                                    success: false,
+                                };
+                                if response_tx.blocking_send(Ok(response)).is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        // Task to create batches from the client stream
+        tokio::spawn(async move {
+            const BATCH_SIZE: usize = 16;
+            const BATCH_TIMEOUT: Duration = Duration::from_millis(500);
+            let mut batch_ids = Vec::with_capacity(BATCH_SIZE);
+            let mut batch_images = Vec::with_capacity(BATCH_SIZE);
+
+            loop {
+                match tokio::time::timeout(BATCH_TIMEOUT, request_stream.next()).await {
+                    Ok(Some(Ok(req))) => {
+                        batch_ids.push(req.document_id);
+                        batch_images.push(req.image);
+
+                        if batch_ids.len() >= BATCH_SIZE {
+                            let batch = ImageBatch {
+                                document_ids: batch_ids,
+                                images: batch_images,
+                            };
+                            if batch_tx.send(batch).await.is_err() {
+                                break;
+                            }
+                            batch_ids = Vec::with_capacity(BATCH_SIZE);
+                            batch_images = Vec::with_capacity(BATCH_SIZE);
+                        }
+                    }
+                    Ok(None) | Err(_) => {
+                        if !batch_ids.is_empty() {
+                            let batch = ImageBatch {
+                                document_ids: batch_ids,
+                                images: batch_images,
+                            };
+                            let _ = batch_tx.send(batch).await;
+                        }
+                        break;
+                    }
+                    Ok(Some(Err(e))) => {
+                        eprintln!("Client stream error: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        let output_stream = ReceiverStream::new(response_rx);
+        Ok(Response::new(Box::pin(output_stream)))
+    }
+}

--- a/src/Eidolon/src/main.rs
+++ b/src/Eidolon/src/main.rs
@@ -1,0 +1,40 @@
+mod clipembedder; // Renamed from 'clipembedder'
+mod utils;
+
+use crate::clipembedder::model::ClipEmbeddingModel;
+use crate::clipembedder::proto::{clip_embedder_server, ClipEmbedderServer};
+use crate::clipembedder::service::ClipEmbedderService;
+use std::sync::{Arc, Mutex};
+use tonic::transport::Server;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Initializing CLIP model and device...");
+    let model = ClipEmbeddingModel::new("openai/clip-vit-base-patch32")?;
+    println!(
+        "CLIP Model loaded successfully on device: {:?}.",
+        model.device.location()
+    );
+
+    let shared_model = Arc::new(Mutex::new(model));
+
+    let clip_service = ClipEmbedderService {
+        model: shared_model,
+    };
+
+    let addr = "[::1]:50051".parse()?;
+    println!("gRPC ClipEmbedderServer listening on {}", addr);
+
+    let (health_reporter, health_service) = tonic_health::server::health_reporter();
+    health_reporter
+        .set_serving::<ClipEmbedderServer<ClipEmbedderService>>()
+        .await;
+
+    Server::builder()
+        .add_service(ClipEmbedderServer::new(clip_service))
+        .add_service(health_service)
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}

--- a/src/Eidolon/src/utils.rs
+++ b/src/Eidolon/src/utils.rs
@@ -1,0 +1,5 @@
+use candle_core::Tensor;
+
+pub fn normalize_l2(v: &Tensor) -> candle_core::error::Result<Tensor> {
+    v.broadcast_div(&v.sqr()?.sum_keepdim(1)?.sqrt()?)
+}


### PR DESCRIPTION
This pull request introduces a new Rust crate called `Eidolon`, which implements a gRPC server for multimodal (text and image) embeddings using the CLIP model. The main features include a gRPC service for embedding text and images, batch streaming for image indexing, and integration with the HuggingFace Hub and Candle ML libraries. The implementation is modular, with clear separation between model logic, service definitions, and protocol buffers.

The most important changes are:

**Project setup and dependencies:**
- Added a new `Cargo.toml` for the `Eidolon` crate, specifying dependencies for gRPC (`tonic`), machine learning (`candle-core`, `candle-nn`, `candle-transformers`), tokenization, image processing, and more.

**gRPC protocol definitions:**
- Introduced protocol buffer files for:
  - The CLIP embedding service (`clip.proto`), supporting text/image embedding and batch image indexing via streaming.
  - Health checking (`health.proto`) for standard gRPC service health reporting.
  - A simple "Hello World" service (`helloworld.proto`) for testing.

**Core model and embedding logic:**
- Implemented `ClipEmbeddingModel` in `model.rs`, which loads the CLIP model from HuggingFace, handles device selection (CPU/Metal), and provides methods for text and image embedding, including preprocessing and L2 normalization. [[1]](diffhunk://#diff-3d417c0978c05aaa584df954bae386ac20587b5d6a5b2b5563906c145b844ccfR1-R123) [[2]](diffhunk://#diff-100cc66c38345070909115cf2eafbbfee9eab72b0ec8916e3daa186585e679a6R1-R5)

**gRPC service implementation:**
- Developed `ClipEmbedderService` in `service.rs`, exposing gRPC endpoints for text/image embedding and batch image indexing, with efficient batching and error handling.

**Server initialization and integration:**
- Added `main.rs` to initialize the CLIP model, set up the gRPC server, register health checks, and start serving requests on port 50051.

**Other supporting changes:**
- Modularized the `clipembedder` component and included protocol bindings. [[1]](diffhunk://#diff-b057d042a135fa82438ef984ce5d6784faf480ed68af6e0fc621fe111f88d1d5R1-R4) [[2]](diffhunk://#diff-c6f3e0752a25c089a72760d568bc40481284951b24a287d451345f7ca0ab2763R1-R4)
- Simplified the build process to only compile `clip.proto` by default.

This PR sets up the foundation for a scalable, multimodal embedding service in Rust using modern ML and gRPC tooling.